### PR TITLE
Reference to Mac OS X binary added

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The recommended way to get PP binaries is to compile them from the sources. Anyw
 
 -   Debian (64 bit binaries): <http://cdsoft.fr/pp/pp-linux-x86_64.txz>
 -   Windows (32 bit binaries running on both 32 and 64 bit Windows): <http://cdsoft.fr/pp/pp-win.7z>
+-   Mac OS X (64 bit binaries): <http://cdsoft.fr/pp/pp-darwin-x86_64.txz>
 
 Usage
 =====

--- a/doc/pp.html
+++ b/doc/pp.html
@@ -88,6 +88,7 @@
 <ul>
 <li>Debian (64 bit binaries): <a href="http://cdsoft.fr/pp/pp-linux-x86_64.txz" class="uri">http://cdsoft.fr/pp/pp-linux-x86_64.txz</a></li>
 <li>Windows (32 bit binaries running on both 32 and 64 bit Windows): <a href="http://cdsoft.fr/pp/pp-win.7z" class="uri">http://cdsoft.fr/pp/pp-win.7z</a></li>
+<li>Mac OS X (64 bit binaries): <a href="http://cdsoft.fr/pp/pp-darwin-x86_64.txz" class="uri">http://cdsoft.fr/pp/pp-darwin-x86_64.txz</a></li>
 </ul>
 <h1 id="usage">Usage</h1>
 <p><code>pp</code> is a simple preprocessor written in Haskell. It’s mainly designed for Pandoc but may be used as a generic preprocessor. It is not intended to be as powerful as GPP for instance but is a simple implementation for my own needs, as well as an opportunity to play with Haskell.</p>

--- a/src/pp.md
+++ b/src/pp.md
@@ -73,6 +73,7 @@ Anyway if you have no Haskell compiler, you can try these precompiled binaries:
 
 - Debian (64 bit binaries): <http://cdsoft.fr/pp/pp-linux-x86_64.txz>
 - Windows (32 bit binaries running on both 32 and 64 bit Windows): <http://cdsoft.fr/pp/pp-win.7z>
+- Mac OS X (64 bit binaries): <http://cdsoft.fr/pp/pp-darwin-x86_64.txz>
 
 Usage
 =====


### PR DESCRIPTION
Hi,
You could find Mac OS X binary here - https://github.com/dlardi/pp/releases/download/v1.0/pp-darwin-x86_64.txz