### PR TITLE
Use GNU tar on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ pp-linux-%.txz: $(PP) doc/pp.html
 
 pp-darwin-%.txz: $(PP) doc/pp.html
 	@$(call title,"MacOS binary archive: $@")
-	tar cJf $@ --transform='s,.*/,,' $^
+	gtar cJf $@ --transform='s,.*/,,' $^
 
 #####################################################################
 # Dependencies

--- a/doc/pp.md
+++ b/doc/pp.md
@@ -60,7 +60,7 @@ Installation
 1. Download and extract [pp.tgz].
 2. Run `make`.
 
-[PP] is written in [Haskell] and is built with [Stack].
+[PP] is written in [Haskell] and is built with [Stack]. On MacOS, running `make` requires the GNU version of `tar` which can be installed with `brew install gnu-tar`.
 
 **Installation**:
 


### PR DESCRIPTION
The version of tar built into MacOS does not support `--transform`, which makes `make` fail. 

This PR uses GNU tar instead, which can be installed using Homebrew and, without affecting the system-provided tar, be called as `gtar`.