### PR TITLE
make pp.md a bit more portable (to non RedHat *nix systems)

### DIFF
--- a/doc/pp.md
+++ b/doc/pp.md
@@ -93,7 +93,7 @@ Anyway if you have no Haskell compiler, you can try some precompiled binaries.
 
 - Latest Linux and Windows binaries:
 
-    - Fedora §sh[(cat /etc/redhat-release | tr -d -c "[0-9]") || true] (64 bit): <https://cdsoft.fr/pp/pp-linux-x86_64.txz>
+    - §sh[(uname -s -r -m) || true]: <https://cdsoft.fr/pp/pp-linux-x86_64.txz>
     - Windows (64 bit): <https://cdsoft.fr/pp/pp-win.7z>
 
 - Older version archive:

--- a/src/Preprocessor.hs
+++ b/src/Preprocessor.hs
@@ -1117,7 +1117,7 @@ parseImageAttributes env s = (localPath, linkPath, attrs)
             let (xs, cs') = span (/=right) cs
             in (xs, dropWhile (==right) cs')
 
--- "ressource name content" writes content (a C string containing PlantUML)
+-- "resource name content" writes content (a C string containing PlantUML)
 -- to a temporary file. It returns the path of the temporary file so the caller
 -- can execute it.
 resource :: FilePath -> (Ptr CChar, Ptr CInt) -> IO FilePath


### PR DESCRIPTION
I am using a bash script here, thoug hit might make more sense to use Haskell for this, if it has a nice portable way to get this kind of info.

with this change, `make doc` seems to work fine on my systme too (it only fails because I don't have lua nor Rscript installed; if I remove tose two sections, it works)